### PR TITLE
Fix: Error: Couldn't find key logs.region in ConfigMap amazon-cloudwatch/cluster-info

### DIFF
--- a/amazon-cloudwatch/fluentd-configmap-cluster-info.yaml.tmpl
+++ b/amazon-cloudwatch/fluentd-configmap-cluster-info.yaml.tmpl
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 data:
-  # Configuration is in Json format. No matter what configure change you make,
-  # please keep the Json blob valid.
+  # The below configuration file is in JSON format.
+  # Please ensure you keep it well-formed if you modify it.
   cluster-info.json: |
     {
       "cluster": {

--- a/amazon-cloudwatch/fluentd-configmap-cluster-info.yaml.tmpl
+++ b/amazon-cloudwatch/fluentd-configmap-cluster-info.yaml.tmpl
@@ -1,6 +1,8 @@
 ---
 apiVersion: v1
 data:
+  cluster.name: {{ .ClusterName }}
+  logs.region: {{ .Region }}
   # The below configuration file is in JSON format.
   # Please ensure you keep it well-formed if you modify it.
   cluster-info.json: |


### PR DESCRIPTION
Follows up on #3.

### Why?

Fixes:
```
Error: Couldn't find key logs.region in ConfigMap amazon-cloudwatch/cluster-info
```

Besides, this is what is generated by the command mentioned in the Amazon documentation:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html#ContainerInsights-install-FluentD

```console
$ kubectl create configmap cluster-info \
>     --from-literal=cluster.name=${CLUSTER} \
>     --from-literal=logs.region=${REGION} -n amazon-cloudwatch
configmap/cluster-info created

$ kubectl get cm cluster-info -n amazon-cloudwatch -o yaml
apiVersion: v1
data:
  cluster.name: ${CLUSTER}
  logs.region: ${REGION}
kind: ConfigMap
metadata:
  name: cluster-info
  namespace: amazon-cloudwatch
```

See also: https://github.com/weaveworks/eks-gitops-example/pull/3/files#r317047875

### Before

```console
$ kubectl get po --all-namespaces
NAMESPACE              NAME                                                      READY   STATUS                       RESTARTS   AGE
[...]
amazon-cloudwatch      fluentd-cloudwatch-7fncs                                  0/1     CreateContainerConfigError   0          4m26s
[...]
```

```console
$ kubectl -n amazon-cloudwatch describe po fluentd-cloudwatch-7fncs
[...]
  Warning  Failed     2m40s (x8 over 3m53s)  kubelet, ip-192-168-95-53.ap-northeast-1.compute.internal  Error: Couldn't find key logs.region in ConfigMap amazon-cloudwatch/cluster-info
[...]
```

### After

```console
$ kubectl get po -n amazon-cloudwatch
NAME                       READY   STATUS             RESTARTS   AGE
[...]
fluentd-cloudwatch-7fncs   1/1     Running            0          31m
```