### PR TITLE
Fix cloudwatch-agent's CrashLoopBackOff on Error: no outputs found

### DIFF
--- a/amazon-cloudwatch/cloudwatch-agent-configmap.yaml.tmpl
+++ b/amazon-cloudwatch/cloudwatch-agent-configmap.yaml.tmpl
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 data:
-  # Configuration is in Json format. No matter what configure change you make,
-  # please keep the Json blob valid.
+  # The below configuration file is in JSON format.
+  # Please ensure you keep it well-formed if you modify it.
   cwagentconfig.json: |
     {
       "structuredlogs": {

--- a/amazon-cloudwatch/cloudwatch-agent-configmap.yaml.tmpl
+++ b/amazon-cloudwatch/cloudwatch-agent-configmap.yaml.tmpl
@@ -5,7 +5,7 @@ data:
   # Please ensure you keep it well-formed if you modify it.
   cwagentconfig.json: |
     {
-      "structuredlogs": {
+      "logs": {
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .ClusterName }}",


### PR DESCRIPTION
Follows up on #3.

### Why?

Fixes `cloudwatch-agent`'s `CrashLoopBackOff` on:
```
Error: no outputs found, did you provide a valid config file?
```

Also, the `ConfigMap` available at https://s3.amazonaws.com/cloudwatch-agent-k8s-yamls/kubernetes-monitoring/cwagent-configmap.yaml has `logs` instead of `structuredlogs`.

### Before / With `structuredlogs`

```console
$ kubectl get po -n amazon-cloudwatch
NAME                       READY   STATUS             RESTARTS   AGE
cloudwatch-agent-x9qrv     0/1     CrashLoopBackOff   5          4m25s
```
```console
$ kubectl -n amazon-cloudwatch logs cloudwatch-agent-x9qrv
[...]
E! Error: no outputs found, did you provide a valid config file?
```

### After / With `logs`

```console
$ kubectl get po -n amazon-cloudwatch
NAME                       READY   STATUS    RESTARTS   AGE
cloudwatch-agent-7sqp2     1/1     Running   0          4s
[...]
```
