### PR TITLE
Use branch instead of git tag

### DIFF
--- a/demo/helm-release.yaml
+++ b/demo/helm-release.yaml
@@ -7,5 +7,5 @@ spec:
   releaseName: podinfo
   chart:
     git: https://github.com/stefanprodan/podinfo
-    ref: 3.0.0
+    ref: v3.x
     path: charts/podinfo


### PR DESCRIPTION
Helm Operator RC.3 is unable to upgrade charts coming from git tags. Changed to git branch until this gets fixed.