### PR TITLE
adding IAM requirements

### DIFF
--- a/kube-system/app-dev-iam.yaml
+++ b/kube-system/app-dev-iam.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: app-dev-iam
+
+iam:
+  withOIDC: true
+  - metadata:
+      name: cluster-autoscaler
+      namespace: kube-system
+      labels: {aws-usage: "cluster-ops"}
+    attachPolicy: # inline policy can be defined along with `attachPolicyARNs`
+      Version: "2012-10-17"
+      Statement:
+      - Effect: Allow
+        Action:
+        - "autoscaling:DescribeAutoScalingGroups"
+        - "autoscaling:DescribeAutoScalingInstances"
+        - "autoscaling:DescribeLaunchConfigurations"
+        - "autoscaling:DescribeTags"
+        - "autoscaling:SetDesiredCapacity"
+        - "autoscaling:TerminateInstanceInAutoScalingGroup"
+        Resource: '*'
+  withAddonPolicies:
+        autoScaler: true
+        cloudWatch: true


### PR DESCRIPTION
As the app-dev profile includes both cloudwatch and CA components we need to accompany the demo with the requisite permissions to access the AWS API's. Im not sure if Kubernetes-system is the right place (although it is the right namespace and has associated components). This could live in a separate directory for clarity but either way we need to push this config so the Autoscaler doesnt hang and the cloudwatch logs can be pushed as the demo suggests.