### PR TITLE
Updated fluentd-demonset apiVersion

### DIFF
--- a/amazon-cloudwatch/fluentd-daemonset.yaml
+++ b/amazon-cloudwatch/fluentd-daemonset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-cloudwatch
@@ -7,6 +7,9 @@ metadata:
   labels:
     k8s-app: fluentd-cloudwatch
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-cloudwatch
   template:
     metadata:
       labels:


### PR DESCRIPTION
Deprecated "extensions/v1beta1" was removed in Kubernetes 1.16, so I migrated fluentd-demonset from "extensions/v1beta1" to "apps/v1" and added required selector in spec.